### PR TITLE
feat: Enable mouse click interaction and add key press styling to Drumkit

### DIFF
--- a/DrumKit/main.js
+++ b/DrumKit/main.js
@@ -1,18 +1,35 @@
-function playSound(n) {
-  const audio = document.querySelector(`audio[data-key="${n}"]`);
-  const key = document.querySelector(`.key[data-key="${n}"]`);
+
+function playSound(keyCode) {
+  const audio = document.querySelector(`audio[data-key="${keyCode}"]`);
+  const key = document.querySelector(`button[data-key="${keyCode}"]`);
+
+  if (!audio) return; 
+
   key.classList.add("clicked");
+  audio.currentTime = 0;
+  audio.play().catch(error => {
+    console.error("Error playing audio: ", error.message);
+  });
 
   setTimeout(() => {
     key.classList.remove("clicked");
   }, 300);
-
-  if (!audio) return;
-  audio.currentTime = 0;
-  audio.play();
 }
 
-window.document.addEventListener("keydown", (e) => {
-  console.log(e.key, e.key.toUpperCase().charCodeAt(0));
-  playSound(e.key.toUpperCase().charCodeAt(0));
+function handleKeyOrMouseClick(event) {
+  let keyCode;
+
+  if (event.type === "keydown") {
+    keyCode = event.keyCode;
+  } else if (event.type === "click") {
+    keyCode = parseInt(event.target.getAttribute("data-key"));
+  }
+
+  playSound(keyCode);
+}
+
+window.addEventListener("keydown", handleKeyOrMouseClick);
+const keys = document.querySelectorAll(".key");
+keys.forEach(key => {
+  key.addEventListener("click", handleKeyOrMouseClick);
 });

--- a/DrumKit/style.css
+++ b/DrumKit/style.css
@@ -26,7 +26,7 @@ main div {
   gap: 15px;
 }
 .key {
-  border: none;
+  border: 2px solid rgb(75, 64, 64);
   width: 110px;
   height: 100px;
   background-color: rgb(75, 64, 64);
@@ -34,7 +34,8 @@ main div {
   transition: 0.3s;
   border-radius: 12px;
 }
-.clicked {
-  scale: 1.1;
+.key.clicked {
+  border-color: white;
+  transform: scale(1.1);
   opacity: 0.8;
 }


### PR DESCRIPTION
Drumkit

This commit allows users to trigger sounds by clicking drum buttons, expanding interaction beyond keyboard keys. Implemented visual enhancement: when a drum key is pressed, its border changes to white, providing immediate feedback to the user.